### PR TITLE
Fixing issues

### DIFF
--- a/maze-game/Player.java
+++ b/maze-game/Player.java
@@ -261,6 +261,7 @@ public class Player extends Actor
      */
     private void collectWallBreaker()
     {
+        MyWorld.score += 10;
         hasWallBreaker = true;
         Actor WallBreaker;
         WallBreaker = getOneObjectAtOffset(0, 0, WallBreaker.class);
@@ -277,6 +278,7 @@ public class Player extends Actor
      */
     private void teleport()
     {
+        hasTeleport = false;
         getWorld().removeObjects(getWorld().getObjects(Tele_option_3.class));
         Greenfoot.playSound("teleport.mp3");
         setLocation(15, 30);

--- a/maze-game/TimeFilter.java
+++ b/maze-game/TimeFilter.java
@@ -29,7 +29,7 @@ public class TimeFilter extends Actor
             //stop
         }
             
-        if(timer>500)
+        if(timer>300)
         {
             MyWorld.stop = false;
             


### PR DESCRIPTION
- teleport item now goes after use, so player can die
- before, after picking the item up, player could use it forever, in turn never dying
- fixed an issue where score wasnt being added for picking up the wallbreaker
- reduced time the time freeze was active for - I felt it was too long

resolves #47
resolves #49